### PR TITLE
improve Token to JavaScript object conversion with recursive handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 **/node_modules
 **/dist
 **/dict
+
+.mcp.json
+.serena

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04fb1c6cf9840d2695a674f542825833bc65219c0f572fce197b6b83dd96ae6"
+checksum = "a8ec9d427d12180a42af6b63740ea93e99c69d5a27ec198d5e959c2d4c684fdf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c63b8e34a3077979625b6244115fb46c14f67feec667910fa6de6df70df4f8"
+checksum = "a639eb5247728f9d8262dac89d1e973bd961f1c527221401d1b0b5e2c2f60854"
 dependencies = [
  "anyhow",
  "bincode",
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ba368258db675a342a5198712c41faf8a8519d5e81d5f592ae6f46a844deed"
+checksum = "f326bc121d43edfcc0d0af0e360179d3ef930d2606fb7807643e0f4c55021674"
 dependencies = [
  "anyhow",
  "bincode",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bba79994764ffc57f580f317135f5df8ad7cf1e9f6142bdfc4ed9c61e517cc6"
+checksum = "300c60de285a34b6a1932377c6137dcaa1d865872f845c9610db9ba9b40d0045"
 dependencies = [
  "anyhow",
  "bincode",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic-neologd"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fce77e8f9314f40218ffb44df317c09f14cf4cf9e299be230a13e4c1e928f9d"
+checksum = "5bdebd94f455f8cd62d8dc243846c3402f719c00f3b10bfeaff190735e03e7d6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-ko-dic"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40a9e2bcebff6a71d9f8e2cac5d04d72afa4736c0f1a50d1226406cbe6ea201"
+checksum = "2bfbeb61e0145f2e8916773ee2c58e212cfc991fb10080d9586e1f677ce91932"
 dependencies = [
  "anyhow",
  "bincode",
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-unidic"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1454b4a90ec736f934f33ee1c59f23f9773153861fb92ae1425574358ff5fbf"
+checksum = "0e5c410114f61f11bf32cbf934cb0562d594606cbfe6905d586444e299bdce70"
 dependencies = [
  "anyhow",
  "bincode",
@@ -927,8 +927,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-wasm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
+ "js-sys",
  "lindera",
  "once_cell",
  "serde",
@@ -1796,21 +1797,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -1822,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1835,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1845,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1858,18 +1860,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+checksum = "80cc7f8a4114fdaa0c58383caf973fc126cf004eba25c9dc639bccd3880d55ad"
 dependencies = [
  "js-sys",
  "minicov",
@@ -1880,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+checksum = "c5ada2ab788d46d4bda04c9d567702a79c8ced14f51f221646a16ed39d0e6a5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1891,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-wasm"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "A morphological analysis library for WebAssembly."
 documentation = "https://docs.rs/lindera-wasm"
@@ -35,14 +35,15 @@ once_cell = "1.21.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 serde-wasm-bindgen = "0.6.5"
-wasm-bindgen = { version = "0.2.100" }
+wasm-bindgen = { version = "0.2.101" }
+js-sys = "0.3"
 
-lindera = "1.1.2"
+lindera = "1.2.0"
 
 [dev-dependencies]
-serde_json = "1.0.140"
-wasm-bindgen-test = "0.3.50"
-wasm-bindgen = { version = "0.2.100" }
+serde_json = "1.0.143"
+wasm-bindgen-test = "0.3.51"
+wasm-bindgen = { version = "0.2.101" }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/lindera-wasm/package-lock.json
+++ b/lindera-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lindera-wasm-example",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lindera-wasm-example",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "copy-webpack-plugin": "13.0.1",
         "webpack": "5.101.3",

--- a/lindera-wasm/package.json
+++ b/lindera-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-wasm-example",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Example project for Lindera WASM",
   "scripts": {
     "start": "webpack serve --config webpack.config.js",

--- a/lindera-wasm/src/index.js
+++ b/lindera-wasm/src/index.js
@@ -67,9 +67,17 @@ document.getElementById('runButton').addEventListener('click', () => {
     resultList.innerHTML = '';
 
     // Display the tokens
-    tokens.forEach(token => {
+    console.log('All tokens:', tokens); // Log the entire tokens array
+
+    tokens.forEach((token, index) => {
         const li = document.createElement('li');
-        li.textContent = token.get('text') + ' : ' + token.get('details').join(", "); // Display the text of the token
+        const pre = document.createElement('pre');
+
+        console.log(`Token ${index}:`, token); // Log each individual token object
+
+        pre.textContent = JSON.stringify(token, null, 2);
+        li.appendChild(pre);
+
         resultList.appendChild(li);
     });
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,71 @@ pub fn get_version() -> String {
     VERSION.to_string()
 }
 
-fn token_to_json(token: &mut Token) -> Value {
-    serde_json::json!({
-        "text": token.text,
-        "details": token.details().clone(),
-        "byte_start": token.byte_start,
-        "byte_end": token.byte_end,
-        "word_id": token.word_id,
-    })
+// Convert snake_case to camelCase
+fn to_camel_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = false;
+
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+// Convert Value to JsValue recursively
+fn value_to_js(value: Value) -> Result<JsValue, JsValue> {
+    match value {
+        Value::String(s) => Ok(JsValue::from_str(s.as_str())),
+        Value::Number(n) => {
+            if let Some(i) = n.as_u64() {
+                Ok(JsValue::from_f64(i as f64))
+            } else if let Some(i) = n.as_i64() {
+                Ok(JsValue::from_f64(i as f64))
+            } else if let Some(f) = n.as_f64() {
+                Ok(JsValue::from_f64(f))
+            } else {
+                Ok(JsValue::from_str(&n.to_string()))
+            }
+        }
+        Value::Bool(b) => Ok(JsValue::from_bool(b)),
+        Value::Null => Ok(JsValue::NULL),
+        Value::Array(arr) => {
+            let js_arr = js_sys::Array::new();
+            for item in arr {
+                js_arr.push(&value_to_js(item)?);
+            }
+            Ok(js_arr.into())
+        }
+        Value::Object(map) => {
+            let js_obj = js_sys::Object::new();
+            for (key, val) in map {
+                // Change key to camel case
+                let js_key = JsValue::from_str(to_camel_case(&key).as_str());
+                let js_val = value_to_js(val)?;
+                js_sys::Reflect::set(&js_obj, &js_key, &js_val)
+                    .map_err(|e| JsValue::from_str(&format!("Failed to set property: {e:?}")))?;
+            }
+            Ok(js_obj.into())
+        }
+    }
+}
+
+// Convert Vec<Token> to JsValue (Array of Objects)
+fn convert_to_js_objects(tokens: Vec<Token>) -> Result<JsValue, JsValue> {
+    let js_array = js_sys::Array::new();
+    for mut token in tokens {
+        js_array.push(&value_to_js(token.as_value())?);
+    }
+
+    Ok(js_array.into())
 }
 
 #[wasm_bindgen]
@@ -101,18 +158,12 @@ pub struct Tokenizer {
 #[wasm_bindgen]
 impl Tokenizer {
     pub fn tokenize(&self, input_text: &str) -> Result<JsValue, JsValue> {
-        let mut tokens = self
+        let tokens = self
             .inner
             .tokenize(input_text)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-        let js_value = serde_wasm_bindgen::to_value(
-            &tokens
-                .iter_mut()
-                .map(|token| token_to_json(token))
-                .collect::<Vec<_>>(),
-        )
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let js_value = convert_to_js_objects(tokens)?;
 
         Ok(js_value)
     }
@@ -139,8 +190,20 @@ mod tests {
         let tokens: Vec<Value> = serde_wasm_bindgen::from_value(t).unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].get("text").unwrap(), "関西国際空港");
-        assert_eq!(tokens[1].get("text").unwrap(), "限定");
-        assert_eq!(tokens[2].get("text").unwrap(), "トートバッグ");
+        assert_eq!(tokens[0].get("surface").unwrap(), "関西国際空港");
+        assert_eq!(tokens[1].get("surface").unwrap(), "限定");
+        assert_eq!(tokens[2].get("surface").unwrap(), "トートバッグ");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_camel_case() {
+        use crate::to_camel_case;
+
+        assert_eq!(to_camel_case("a"), "a");
+        assert_eq!(to_camel_case("a_b"), "aB");
+        assert_eq!(to_camel_case("a_b_c"), "aBC");
+        assert_eq!(to_camel_case("a_b_c_d"), "aBCD");
+        assert_eq!(to_camel_case("a_b_c_d_e"), "aBCDE");
     }
 }


### PR DESCRIPTION
improve Token to JavaScript object conversion with recursive handling

- Replace direct serde_json conversion with custom recursive value_to_js function
- Add camelCase conversion for all object keys (snake_case → camelCase)
- Simplify tokenize method using new convert_to_js_objects function
- Update dependencies: lindera 1.1.2→1.2.0, wasm-bindgen→0.2.101
- Add js-sys dependency for better JavaScript interop
- Update frontend to display tokens as formatted JSON for debugging
- Add tests for camelCase conversion
- Update existing tests to use new 'surface' field name